### PR TITLE
added immersed boundary bathymetry, and switched to T/S 

### DIFF
--- a/iceplume.jl
+++ b/iceplume.jl
@@ -1,8 +1,13 @@
 using Pkg
+#Pkg.add("CUDA")
+#Pkg.add("Printf")
+#Pkg.add("Statistics")
+#Pkg.instantiate() # Only need to do this once when you started the repo in another machine
+#Pkg.resolve()
 using Oceananigans
 using Oceananigans.Units
 using Printf
-using CUDA: has_cuda_gpu, @allowscalar, CuArray
+using CUDA: has_cuda_gpu, @allowscalar
 using Statistics: mean
 using Oceanostics
 using Rasters
@@ -26,26 +31,26 @@ end
 
 #++++ Construct grid
 if LES
-    params = (; Lx = 50000,
-              Ly = 100000,
+    params = (; Lx = 50e3,
+              Ly = 100e3,
               Lz = 200,
-              Nx = 250,
-              Ny = 500,
+              Nx = 100,
+              Ny = 200,
               Nz = 100,
               ) 
 
 else
-    params = (; Lx = 50000,
-              Ly = 100000,
-              Lz = 200,
-              Nx = 250, #ideally 512
-              Ny = 500, ##Int(Nx/2*3/5)
-              Nz = 100, #ideally 750
+    params = (; Lx = 3.5,
+              Ly = 0.1,
+              Lz = 1.5,
+              Nx = 100, #ideally 512
+              Ny = 50, ##Int(Nx/2*3/5)
+              Nz = 40, #ideally 750
               )
 end
 
 if arch == CPU() # If there's no CPU (e.g. if we wanna test shit on a laptop) let's use a smaller number of points!
-    params = (; params..., Nx = 16, Ny = 32, Nz = 20)
+    params = (; params..., Nx = 30, Ny = 30, Nz = 20)
 end
 
 # Creates a grid with near-constant spacing `refinement * Lz / Nz`
@@ -55,26 +60,41 @@ stretching = 12  # controls rate of stretching at bottom
 
 # "Warped" height coordinate
 Nz = params.Nz
-
-# Normalized height ranging from 0 to 1
-h(k) = (Nz+ 1 - k) / params.Nz
+h(k) = (Nz + 1 - k) / Nz
 
 # Linear near-surface generator
-ζ₀(k) = 1 + (h(k) - 1) / refinement
+ζ(k) = 1 + (h(k) - 1) / refinement
 
 # Bottom-intensified stretching function
 Σ(k) = (1 - exp(-stretching * h(k))) / (1 - exp(-stretching))
 
 # Generating function
-z_faces(k) = -params.Lz * (ζ₀(k) * Σ(k) - 1)
+z_faces(k) =  params.Lz * (ζ(Nz-k+1) * Σ(Nz-k+1) -1) + params.Lz
 
-grid = RectilinearGrid(arch,
+#need to stretch dx from 5e-6 to .02
+underlying_grid = RectilinearGrid(arch,
                        size = (params.Nx, params.Ny, params.Nz),
                        x = (0, params.Lx),
                        y = (-params.Ly/2, +params.Ly/2),
-                       z = z_faces,
+                       z = (-params.Lz, 0),  #z_faces,
+                       halo = (4, 4, 4),        
                        topology = (Bounded, Periodic, Bounded))
+
+
+#H=200
+bottom(x,y) =  max(- x*160/8000, -(x-8000)*40/42000-160)
+
+grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBottom(bottom))
+
+#h₀ = 50meters
+#width = 5kilometers
+#hill(x) = h₀ * exp(-x^2 / 2width^2)
+#bottom(x) = - 200 + hill(x)
+
+grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBottom(bottom))
+
 @info "Grid" grid
+
 #----
 
 #++++ Creates a dictionary of simulation parameters
@@ -84,79 +104,66 @@ else
     u₁_west = 0 # No mass flux
 end
 
-
-
 # Not necessary, but makes organizing simulations easier and facilitates running on GPUs
 params = (; params...,
-          N²₀ = 2e-4, #  9.83/1028*2/100  1/s (stratification frequency)
+          N²₀ = 0e-6, # 1/s (stratification frequency)
           #z₀ = 300, # m
           #σz_west = 10, # m (height of the dense water inflow at the west boundary)
-          u₁_west = u₁_west, # m/s (speed of water inflow at the west boundary)
+          #u₁_west = u₁_west, # m/s (speed of water inflow at the west boundary)
           #ℓ₀ = 0.1, # m (roughness length)
-          σ = 2000.0seconds, # s (relaxation rate for sponge layer)
+          σ = 2000seconds, # s (relaxation rate for sponge layer)
           #uₑᵥₐᵣ = 0.00, # m/s (velocity variation along the z direction of the east boundary)
-          u_b = 0,    # m s⁻¹, average wind velocity 10 meters above the ocean
-          v_b = 0,    #-10    # m s⁻¹, average wind velocity 10 meters above the ocean
+          u_b = 0.00, # m s⁻¹, average wind velocity 10 meters above the ocean
+          v_b = 0.00, # m s⁻¹, average wind velocity 10 meters above the ocean
           )
 #----
 
 #++++ Conditions opposite to the ice wall (@ infinity)
 if LES
-    b∞(z, parameters) = parameters.N²₀ * z # Linear stratification in the interior (far from ice face)
-else
-    T∞(x, parameters) = 8. - 0.0 * x
-    S∞(x, parameters) = 34.9 - 0.0 * x
-    u∞(x, parameters) = @allowscalar u_b
-    v∞(x, parameters) = @allowscalar v_b
+    Teast(z, parameters) = 4.1 - .5/200 * z
+    Seast(z, parameters) = 34 - 1/200 * z   #first number is surface salinity offshore, this is offshore data
+    Twest(z, parameters) = (z+100).^2/60^2+1.6  #1.6 deg middepth. 4deg at surf and bot
+    Swest(z, parameters) = 31 - 3/200 * z   #
+    u∞(z, parameters) = @allowscalar u_b
+    v∞(z, parameters) = @allowscalar v_b
 end
 #----
 
-#++++ EAST BCs
+#++++ Western BCs
 if LES
-    b_east(y, z, t, p) = b∞(z, p) - 2/1028*9.8 #  delta rho/rho0 * g + p.b₁_west / (1 + exp((z-p.z₀)/p.σz_west))
+  #  b_west(y, z, t, p) = b∞(z, p) #+ p.b₁_west / (1 + exp((z-p.z₀)/p.σz_west))
 else
     if mass_flux
         u_west(y, z, t, p) = p.u₁_west # / (1 + exp((z-p.z₀)/p.σz_west))
     end
 end
-
-#++++ WEST BCs
-
-if LES
-    b_west(y, z, t, p) = b∞(z, p) #+ p.b₁_west / (1 + exp((z-p.z₀)/p.σz_west))
-else
-    if mass_flux
-        u_west(y, z, t, p) = p.u₁_west # / (1 + exp((z-p.z₀)/p.σz_west))
-    end
-end
-
 
 #surface wind stresses
 
 cᴰ = 2.5e-3 # dimensionless drag coefficient
 ρₐ = 1.225  # kg m⁻³, average density of air at sea-level
 ρₒ = 1028   # kg m⁻³, average density of seawater
-Qu = - ρₐ / ρₒ * cᴰ * params.u_b * abs(params.u_b) # m² s⁻²
-Qv = - ρₐ / ρₒ * cᴰ * params.v_b * abs(params.v_b) # m² s⁻²
+Qu = - ρₐ / ρₒ * 2.5e-3 * params.u_b * abs(params.u_b) # m² s⁻²
+Qv = - ρₐ / ρₒ * 2.5e-3 * params.v_b * abs(params.v_b) # m² s⁻²
 
 #++++ Drag BC for v and w
 if LES
-   # const κ = 0.4 # von Karman constant
-   # z₁ = first(znodes(grid, Center())) # Closest grid center to the bottom
-   # cᴰ = 2.5e-3 # (κ / log(z₁ / z₀))^2 # Drag coefficient
-   # x₁ₘₒ = @allowscalar xnodes(grid, Center())[1] # Closest grid center to the bottom
-   # cᴰ = (κ / log(x₁ₘₒ/params.ℓ₀))^2 # Drag coefficient
+ #   const κ = 0.4 # von Karman constant
+ #   x₁ₘₒ = @allowscalar xnodes(grid, Center())[1] # Closest grid center to the bottom
+ #   cᴰ = (κ / log(x₁ₘₒ/params.ℓ₀))^2 # Drag coefficient
 
-    @inline drag_u(x, y, t, v, w, p) = - p.cᴰ * √(u^2 + v^2) * u
-    @inline drag_v(x, y, t, v, w, p) = - p.cᴰ * √(u^2 + v^2) * v
 
-    drag_bc_u = FluxBoundaryCondition(drag_u, field_dependencies=(:u, :v), parameters=(cᴰ=cᴰ,))
-    drag_bc_v = FluxBoundaryCondition(drag_v, field_dependencies=(:v, :v), parameters=(cᴰ=cᴰ,))
+    @inline drag_u(x, y, t, u, v, p) = - cᴰ * √(u^2 + v^2) * u
+    @inline drag_v(x, y, t, u, v, p) = - cᴰ * √(u^2 + v^2) * v
+
+    drag_bc_u = FluxBoundaryCondition(drag_u, field_dependencies=(:u, :v), parameters=(; cᴰ=cᴰ,))
+    drag_bc_v = FluxBoundaryCondition(drag_v, field_dependencies=(:v, :v), parameters=(; cᴰ=cᴰ,))
+
 end
 #----
 #----
 
-#++++ Eastern BCs (freshwater flux)
+#++++ Eastern BCs
 if mass_flux # What comes in has to go out
     params = (; params..., u_out = mean(u_west.(0, grid.zᵃᵃᶜ[1:Nz], 0, (params,))))
     # The function below allows a net mass flux out of exactly u_out, but with variations in the form of
@@ -167,53 +174,38 @@ else
 end
 #----
 
-#++++ Eastern sponge layer 
+
+#++++ West sponge layer 
 # (smoothes out the mass flux and gets rid of some of the build up of buoyancy)
+@inline function west_mask(x, y, z)
+    x0 = 0  #inner location
+    x1 = 5000  #outer location
 
-const Lz = params.Lz
-const Lx = params.Lx
-@inline function east_mask_cos(x, y, z)
-    x₀ = Lx-5000  #inner location
-    x₁ = Lx  #outer location
 
-    if x₀ <= x <= x₁
-        return 1/2 * (1 - cos( π*(x-x₀)/(x₁-x₀) ))
-    elseif x₁ < x
-        return 1.0
-    else
-        return 0.0
+    #if x0 <= x <= x1
+   #     return 1-x/x1
+   # else
+   #     return 0.0
+      
+     return max(min(1-x/x1, 1),0)
+
     end
 end
 
-@inline function west_mask_cos(x, y, z)
-    x₀ = 0  
-    x₁ = 5000 
+#++++ Eastern sponge layer 
 
-    if x₀ <= x <= x₁
-        return 1/2 * (1 - cos( π*(x-x₀)/(x₁-x₀) ))
-    elseif x₁ < x
-        return 1.0
-    else
-        return 0.0
-    end
+@inline function east_mask(x, y, z)
+    x1 = 5000  #bdy width
+    x2 = params.Lx-x1  #inner location
+    x3 = params.Lx  #outer location
+
+ #   if x2 <= x <= x3
+ #       return 1- (params.Lx-x)/x1
+ #   else
+ #       return 0.0
+ #   end
+    return max(min(1- (params.Lx-x)/5000, 1),0)
 end
-
-@inline function east_west_mask_cos(x, y, z)
-    x₀ = 0  
-    x₁ = 5000
-    
-    x2 = Lx-5000  #inner location
-    x3 = Lx  #outer location
-
-    if x₀ <= x <= x₁
-        return 1/2 * (1 - cos( π*(x-x₀)/(x₁-x₀) ))
-    elseif x2 <= x <= x3
-        return 1/2 * (1 - cos( π*(x-x2)/(x3-x2) )) 
-    else
-        return 0.0
-    end
-end
-
 
 if mass_flux
     @inline sponge_u(x, y, z, t, u, p) = -west_mask_cos(x, y, z) * p.σ * (u - u∞(y, z, t, p)) # Nudges u to u∞
@@ -225,22 +217,23 @@ end
 #@inline sponge_T(x, y, z, t, T, p) = -west_mask_cos(x, y, z) * p.σ * (T - T∞(x, p)) # nudges T to T∞
 #@inline sponge_S(x, y, z, t, S, p) = -west_mask_cos(x, y, z) * p.σ * (S - S∞(x, p)) # nudges S to S∞
 #@inline sponge_b(x, y, z, b, p) = -west_mask_cos(x, y, z) * p.σ * (b -  b_west(y, z, t, p)) -east_mask_cos(x, y, z) * p.σ * (b -  b_east(y, z, t, p))# nudges S to S∞
+@inline sponge_T(x, y, z, t, T, p) = -east_mask(x, y, z) / p.σ * (T - Teast(z, p))-west_mask(x, y, z) / p.σ * (T - (Twest(z, p))) # nudges T to T∞
+@inline sponge_S(x, y, z, t, S, p) = -east_mask(x, y, z) / p.σ * (S - Seast(z, p))-west_mask(x, y, z) / p.σ * (S - (Swest(z, p))) # nudges S to S∞
 
-@inline sponge_b(x, y, z , b, p) = -west_mask_cos(x, y, z) * p.σ * (b -  b_west(y, z, p)) -east_mask_cos(x, y, z) * p.σ * (b -  b_east(y, z, p))
+
 
 #----
 
 #++++ Assembling forcings and BCs
-if ext_forcing
- # Fᵤ = Forcing(sponge_u, field_dependencies = :u, parameters = params)
- # Fᵥ = Forcing(sponge_v, field_dependencies = :v, parameters = params)
-  Fb = Forcing(sponge_b, field_dependencies = :b, parameters = params)
-  forcing = ( b = Fb )
-else
+#if ext_forcing
+#  Fᵤ = Forcing(sponge_u, field_dependencies = :u, parameters = params)
+#  Fᵥ = Forcing(sponge_v, field_dependencies = :v, parameters = params)
+#  forcing = (u=Fᵤ, v=Fᵥ, T=FT, S=FS)
+#else
   FT = Forcing(sponge_T, field_dependencies = :T, parameters = params)
   FS = Forcing(sponge_S, field_dependencies = :S, parameters = params)
   forcing = (T=FT, S=FS)
-end
+#end
 
 if mass_flux
     Fᵤ = Forcing(sponge_u, field_dependencies = :u, parameters = params)
@@ -249,25 +242,39 @@ if mass_flux
     forcing = (u=Fᵤ, v=Fᵥ, w=Fw, T=FT, S=FS)
 end
 
+#solve for dTdx and dSdx
+#const a_s = -5.73e-2
+#const L = 3.35e5
+#const c_w = 3974
+#const kappa_S=7.2e-10
+#const kappa_T=1.3e-7
+#const dz = @allowscalar grid.Δzᵃᵃᶜ[Nz]# Lx/Nx; #the dz at the topmost gridpoint
 
-#T_bcs = FieldBoundaryConditions(top = ValueBoundaryCondition(get_T0, field_dependencies=(:T, :S)), 
-#                                west = FluxBoundaryCondition(0), 
-#                                east = FluxBoundaryCondition(0), # Hidden behind sponge layer
-#                                )
+#function get_T0(x, y, t, T, S)
+#    bb = -T- L*kappa_S/(kappa_T*c_w)  #need to define T1
+#    cc = L*kappa_S*a_s*S / (kappa_T*c_w)  #need to define S1
+#    return (-bb-sqrt(bb^2-4*cc))/2
+#end
+
+#function get_S0(x, y, t, T, S)
+#    T0 = get_T0(x, y, t, T, S)
+#    S0 = T0/a_s
+#    return S0
+#end
+
+
+T_bcs = FieldBoundaryConditions(#top = ValueBoundaryCondition(get_T0, field_dependencies=(:T, :S)), 
+                                #west = FluxBoundaryCondition(0), 
+                                #east = FluxBoundaryCondition(0), # Hidden behind sponge layer
+                                )
 
                                 
-#S_bcs = FieldBoundaryConditions(top = ValueBoundaryCondition(get_S0, field_dependencies=(:T, :S)),
-#                                west = FluxBoundaryCondition(0),  
-#                                east = FluxBoundaryCondition(0), # Hidden behind sponge layer
-#                                )
-#w_bcs = FieldBoundaryConditions(east = ValueBoundaryCondition(0),
-#                                west = ValueBoundaryCondition(0),
-#                                )      
-#b_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qu),  # wind stress
-#                                bottom = drag_bc_u,
-#                                )                  
+S_bcs = FieldBoundaryConditions(#top = ValueBoundaryCondition(get_S0, field_dependencies=(:T, :S)),
+                                #west = FluxBoundaryCondition(0),  
+                                #east = FluxBoundaryCondition(0), # Hidden behind sponge layer
+                                )
 u_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qu),  # wind stress
-                                bottom = drag_bc_u,
+                                bottom = drag_bc_u, # # bottom = drag_bc_u,
                                 )
 v_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qv),  # wind stress
                                 bottom = drag_bc_v,
@@ -277,7 +284,8 @@ v_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qv),  # wind stress
 w_bcs = FieldBoundaryConditions(#east = ValueBoundaryCondition(0),
                                 #west = ValueBoundaryCondition(0),
                                 )
-boundary_conditions = (u=u_bcs, v=v_bcs, w=w_bcs)
+                                
+boundary_conditions = (u=u_bcs, v=v_bcs, w=w_bcs, T=T_bcs, S=S_bcs,)
 #----
 
 #++++ Construct model
@@ -287,15 +295,18 @@ else
     closure = ScalarDiffusivity(VerticallyImplicitTimeDiscretization(),ν=1.8e-6, κ=(T=1.3e-7, S=7.2e-10))
 end
 
-θ = 105 # degrees relative to pos. x-axis
+θ = 75 # degrees relative to pos. x-axis
+
 
 model = HydrostaticFreeSurfaceModel(grid = grid, 
                             #advection = WENO(grid=grid, order=5),
                             #timestepper = :RungeKutta3, 
-                           # timestepper = :QuasiAdamsBashforth2, 
-                            tracers = :b,
+                            #timestepper =  :RungeKutta3, #:QuasiAdamsBashforth2, 
+                            tracers = (:T, :S),
+                            buoyancy = Buoyancy(model=SeawaterBuoyancy(equation_of_state=LinearEquationOfState(thermal_expansion = 3.87e-5,
+                            haline_contraction = 7.86e-4)), gravity_unit_vector=(0,0,-1)),
                             #tracers = (:T, :S),
-                            buoyancy = BuoyancyTracer(),
+                            #buoyancy = BuoyancyTracer(),
                             momentum_advection = WENO(),
                             tracer_advection = WENO(),
                             #buoyancy = Buoyancy(model=SeawaterBuoyancy(equation_of_state=LinearEquationOfState(thermal_expansion = 3.87e-5,
@@ -308,27 +319,26 @@ model = HydrostaticFreeSurfaceModel(grid = grid,
                             boundary_conditions = boundary_conditions,
                             )
 @info "Model" model
+
 #----
 
 #++++ Create simulation
-using Oceanostics: SingleLineProgressMessenger
+using Oceanostics.ProgressMessengers: BasicTimeMessenger
 
-Δt₀ = 1/2 * minimum_zspacing(grid) / (u₁_west + 1e-1)
+Δt₀ = 1/2 * minimum_yspacing(grid) / 1  #Δt₀ = 1/2 * minimum_zspacing(grid) / (u₁_west + 1e-1)
 simulation = Simulation(model, Δt=Δt₀,
-                        stop_time = 2400seconds, # when to stop the simulation
+                        stop_time = 15days, # when to stop the simulation
 )
 
 #++++ Adapt time step
-wizard = TimeStepWizard(cfl=0.6, # How to adjust the time step
-                       # diffusive_cfl=5,
-                        max_change=1.02, min_change=0.2, max_Δt=0.5/√params.N²₀, min_Δt=0.1seconds)
+wizard = TimeStepWizard(cfl=0.8, # How to adjust the time step
+                        #diffusive_cfl=5,
+                        max_change=1.02, min_change=0.2, min_Δt=0.1seconds)
 simulation.callbacks[:wizard] = Callback(wizard, IterationInterval(2)) # When to adjust the time step
 #----
 
 #++++ Printing to screen
-start_time = time_ns() * 1e-9
-progress = SingleLineProgressMessenger(SI_units=true,
-                                       initial_wall_time_seconds=start_time)
+progress = BasicTimeMessenger()
 simulation.callbacks[:progress] = Callback(progress, IterationInterval(10)) # when to print on screen
 #----
 
@@ -338,34 +348,40 @@ simulation.callbacks[:progress] = Callback(progress, IterationInterval(10)) # wh
 #++++ Impose initial conditions
 u, v, w =  model.velocities
 
-b = model.tracers.b
-#S = model.tracers.S
+T = model.tracers.T
+S = model.tracers.S
 
 if interpolated_IC
-
     filename = "IC_part.nc"
     @info "Imposing initial conditions from existing NetCDF file $filename"
 
     using Rasters
     rs = RasterStack(filename, name=(:u, :v, :w, :T, :S))
 
-    @allowscalar u[1:grid.Nx+1, 1:grid.Ny, 1:grid.Nz] .= CuArray(rs.u[ Ti=Near(Inf) ])
-    @allowscalar v[1:grid.Nx, 1:grid.Ny, 1:grid.Nz] .= CuArray(rs.v[ Ti=Near(Inf) ])
-    @allowscalar w[1:grid.Nx, 1:grid.Ny, 1:grid.Nz+1] .= CuArray(rs.w[ Ti=Near(Inf) ])
+    u[1:grid.Nx+1, 1:grid.Ny, 1:grid.Nz] .= Array(rs.u[ Ti=Near(Inf) ])
+    v[1:grid.Nx, 1:grid.Ny, 1:grid.Nz] .= Array(rs.v[ Ti=Near(Inf) ])
+    w[1:grid.Nx, 1:grid.Ny, 1:grid.Nz+1] .= Array(rs.w[ Ti=Near(Inf) ])
 
-    @allowscalar S[1:grid.Nx, 1:grid.Ny, 1:grid.Nz] .= CuArray(rs.S[ Ti=Near(Inf) ])
-    @allowscalar T[1:grid.Nx, 1:grid.Ny, 1:grid.Nz] .= CuArray(rs.T[ Ti=Near(Inf) ])
+    S[1:grid.Nx, 1:grid.Ny, 1:grid.Nz] .= Array(rs.S[ Ti=Near(Inf) ])
+    T[1:grid.Nx, 1:grid.Ny, 1:grid.Nz] .= Array(rs.T[ Ti=Near(Inf) ])
 
 else
     @info "Imposing initial conditions from scratch"
 
- 
+#    const T_i=-0.3
+#    const S_i=T_i/a_s
+#    const Le=kappa_T/kappa_S
+#    const delta_B=0.0017
 
-    b_ic(x, y, z) = b∞(z, params)- 2/1028*9.8*x/Lx
-    
+
+    T_ic(x, y, z) = Teast(z, params)
+
+    S_ic(x, y, z) = Seast(z, params)
+
+ #   T_ic(x, y, z) = T∞(z, params)
  #   T_ic(x,y,z) =  2/pi*(T∞(x,params)-T_i)*atan((Lz-z)/delta_B)+T_i
 
-#    S_ic(x, y, z) = S∞(x, params)
+ #   S_ic(x, y, z) = S∞(z, params)
  #   S_ic(x, y, z) = 2/pi*(S∞(x,params)-S_i)*atan((Lz-z)/delta_B*Le^(1/3))+S_i
     
     uᵢ = 0.005*rand(size(u)...)
@@ -376,7 +392,7 @@ else
     vᵢ .-= mean(vᵢ)
     wᵢ .-= mean(wᵢ)
     uᵢ .+= 0 #params.u_b
-    vᵢ .+= -0.2 #params.v_b    
+    vᵢ .+= -.25 #params.v_b    
 
  
 #    plumewidth(x)=.0833*x;
@@ -393,7 +409,7 @@ else
     
 # uᵢ .+=  u_ic(x,y,z)
 
-    set!(model, u=uᵢ, v=vᵢ, w=wᵢ, b=b_ic)
+    set!(model, u=uᵢ, v=vᵢ, w=wᵢ, T=T_ic, S=S_ic)
 end
 #----
 
@@ -403,7 +419,7 @@ end
 # y-component of vorticity
 ω_z = Field(∂x(v) - ∂y(u))
 
-outputs = (; u, v, w, b, ω_z)
+outputs = (; u, v, w, T, S, ω_z)
 
 if mass_flux
     saved_output_prefix = "iceplume"
@@ -413,7 +429,7 @@ end
 saved_output_filename = saved_output_prefix * ".nc"
 checkpointer_prefix = "checkpoint_" * saved_output_prefix
 
-#+++ Check for checkpoints
+#++++ Check for checkpoints
 if any(startswith("$(checkpointer_prefix)_iteration"), readdir(rundir))
     @warn "Checkpoint $saved_output_prefix found. Assuming this is a pick-up simulation! Setting `overwrite_existing=false`."
     overwrite_existing = false
@@ -421,16 +437,16 @@ else
     @warn "No checkpoint for $saved_output_prefix found. Setting `overwrite_existing=true`."
     overwrite_existing = true
 end
-#---
+#----
 
 simulation.output_writers[:surface_slice_writer] =
-    NetCDFOutputWriter(model, (; u,v,w, b), filename="top.nc",
-                       schedule=TimeInterval(864), indices=(:, :, 1),
+    NetCDFOutputWriter(model, (; u,v,w, T,S), filename="top.nc",
+                       schedule=TimeInterval(8640), indices=(:, :, 1),
                         overwrite_existing = overwrite_existing)
 
 simulation.output_writers[:y_slice_writer] =
-    NetCDFOutputWriter(model,(; u, v, w, b), filename="midy.nc",
-                       schedule=TimeInterval(864), indices=(:, round(params.Ny/2), :), 
+    NetCDFOutputWriter(model,(; u, v, w, T,S), filename="midy.nc",
+                       schedule=TimeInterval(8640), indices=(:, round(params.Ny/2), :), 
                        overwrite_existing = overwrite_existing)
 
 ccc_scratch = Field{Center, Center, Center}(model.grid) # Create some scratch space to save memory
@@ -438,30 +454,30 @@ ccc_scratch = Field{Center, Center, Center}(model.grid) # Create some scratch sp
 uv = Field((@at (Center, Center, Center) u*v))
 uw = Field((@at (Center, Center, Center) u*w))
 vw = Field((@at (Center, Center, Center) v*w))
-ub = Field((@at (Center, Center, Center) u*b))
-vb = Field((@at (Center, Center, Center) v*b))
-wb = Field((@at (Center, Center, Center) w*b))
-#uS = Field((@at (Center, Center, Center) u*S))
-#vS = Field((@at (Center, Center, Center) v*S))
-#wS = Field((@at (Center, Center, Center) w*S))
+uT = Field((@at (Center, Center, Center) u*T))
+vT = Field((@at (Center, Center, Center) v*T))
+wT = Field((@at (Center, Center, Center) w*T))
+uS = Field((@at (Center, Center, Center) u*S))
+vS = Field((@at (Center, Center, Center) v*S))
+wS = Field((@at (Center, Center, Center) w*S))
 
 u_yavg = Average(u, dims=(2))
 v_yavg = Average(v, dims=(2))
 w_yavg = Average(w, dims=(2))
-b_yavg = Average(b, dims=(2))
-#S_yavg = Average(S, dims=(2))
+T_yavg = Average(T, dims=(2))
+S_yavg = Average(S, dims=(2))
 uv_yavg = Average(uv, dims=(2))
 uw_yavg = Average(uw, dims=(2))
 vw_yavg = Average(vw, dims=(2))
-ub_yavg = Average(ub, dims=(2))
-vb_yavg = Average(vb, dims=(2))
-wb_yavg = Average(wb, dims=(2))
-#uS_yavg = Average(uS, dims=(2))
-#vS_yavg = Average(vS, dims=(2))
-#wS_yavg = Average(wS, dims=(2))
+uT_yavg = Average(uT, dims=(2))
+vT_yavg = Average(vT, dims=(2))
+wT_yavg = Average(wT, dims=(2))
+uS_yavg = Average(uS, dims=(2))
+vS_yavg = Average(vS, dims=(2))
+wS_yavg = Average(wS, dims=(2))
 
 output_interval=86400seconds
-simulation.output_writers[:averages] = NetCDFOutputWriter(model, (; u_yavg, v_yavg, w_yavg, b_yavg, uv_yavg, uw_yavg, vw_yavg, ub_yavg, vb_yavg, wb_yavg ),
+simulation.output_writers[:averages] = NetCDFOutputWriter(model, (; u_yavg, v_yavg, w_yavg, T_yavg, S_yavg, uv_yavg, uw_yavg, vw_yavg, uT_yavg, vT_yavg, wT_yavg,  uS_yavg, vS_yavg, wS_yavg, ),
                                                           schedule = AveragedTimeInterval(output_interval, window=output_interval),
                                                           filename = "timeavgedfields_yavg.nc",
                                                           overwrite_existing = overwrite_existing)
@@ -515,7 +531,7 @@ simulation.output_writers[:checkpointer] = Checkpointer(model,
                                                         )
 
 #---
- 
-#+++ Ready to press the big red button: 
-run!(simulation; pickup=true) 
-#---
+
+#++++ Ready to press the big red button:
+run!(simulation; pickup=true)
+#----

--- a/pbs_iceplume.sh
+++ b/pbs_iceplume.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -l
+#PBS -A UCLA0052
+#PBS -N refreflo
+#PBS -k eod
+#PBS -o logs/DNSkerr.out
+#PBS -e logs/DNSkerr.err
+#PBS -l walltime=12:00:00
+#PBS -q casper
+#PBS -l select=1:ncpus=1:ngpus=1
+#PBS -l gpu_type=v100
+#PBS -M zhazorken@gmail.com
+#PBS -m abe
+
+# Clear the environment from any previously loaded modules
+module purge
+module load ncarenv/23.10
+module load julia/1.9.2 cuda
+
+module load peak-memusage
+module li
+
+#/glade/u/apps/ch/opt/usr/bin/dumpenv # Dumps environment (for debugging with CISL support)
+
+#export JULIA_DEPOT_PATH="/glade/work/tomasc/.julia_bkp"
+export JULIA_DEPOT_PATH="/glade/work/kenzhao/.julia"
+
+peak_memusage julia --project iceplume.jl --simname=DNSgayen3casper --factor=2 2>&1 | tee out/DNSgayen1.out


### PR DESCRIPTION
@tomchor 

I'm having an error when running this on GPUs (it works on CPU) that pops up when I 
try to set up the immersed boundary bathymetry. It says it's out of resources? Can you maybe test on a GPU to see if you're getting the same error? 


```Julia

┌ Warning: CUDA runtime library libcusparse.so.12 was loaded from a system path. This may cause errors.
│ Ensure that you have not set the LD_LIBRARY_PATH environment variable, or that it does not contain paths to CUDA libraries.
└ @ CUDA /glade/work/kenzhao/.julia/packages/CUDA/rXson/src/initialization.jl:189
ERROR: LoadError: CUDA error: too many resources requested for launch (code 701, ERROR_LAUNCH_OUT_OF_RESOURCES)
Stacktrace:
  [1] throw_api_error(res::CUDA.cudaError_enum)
    @ CUDA /glade/work/kenzhao/.julia/packages/CUDA/rXson/lib/cudadrv/libcuda.jl:27
  [2] check
    @ /glade/work/kenzhao/.julia/packages/CUDA/rXson/lib/cudadrv/libcuda.jl:34 [inlined]
  [3] cuLaunchKernel
    @ /glade/work/kenzhao/.julia/packages/CUDA/rXson/lib/utils/call.jl:26 [inlined]
  [4] (::CUDA.var"#891#892"{Bool, Int64, CUDA.CuStream, CUDA.CuFunction, CUDA.CuDim3, CUDA.CuDim3})(kernelParams::Vector{Ptr{Nothing}})
    @ CUDA /glade/work/kenzhao/.julia/packages/CUDA/rXson/lib/cudadrv/execution.jl:69
  [5] macro expansion
    @ /glade/work/kenzhao/.julia/packages/CUDA/rXson/lib/cudadrv/execution.jl:33 [inlined]
  [6] macro expansion
    @ ./none:0 [inlined]
  [7] pack_arguments(::CUDA.var"#891#892"{Bool, Int64, CUDA.CuStream, CUDA.CuFunction, CUDA.CuDim3, CUDA.CuDim3}, ::CUDA.KernelState, ::CartesianIndices{3, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}, Base.OneTo{Int64}}}, ::CartesianIndices{3, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}, Base.OneTo{Int64}}}, ::CUDA.CuDeviceArray{Float64, 4, 1}, ::Field{Center, Center, Nothing, Nothing, Nothing, Nothing, OffsetArrays.OffsetArray{Float64, 3, CUDA.CuDeviceArray{Float64, 3, 1}}, Float64, Nothing, Nothing, Nothing})
    @ CUDA ./none:0
  [8] #launch#890
    @ /glade/work/kenzhao/.julia/packages/CUDA/rXson/lib/cudadrv/execution.jl:62 [inlined]
  [9] #896
    @ /glade/work/kenzhao/.julia/packages/CUDA/rXson/lib/cudadrv/execution.jl:136 [inlined]
 [10] macro expansion
    @ /glade/work/kenzhao/.julia/packages/CUDA/rXson/lib/cudadrv/execution.jl:95 [inlined]
 [11] macro expansion
    @ ./none:0 [inlined]
 [12] convert_arguments
    @ ./none:0 [inlined]
 [13] #cudacall#895
    @ /glade/work/kenzhao/.julia/packages/CUDA/rXson/lib/cudadrv/execution.jl:135 [inlined]
 [14] cudacall
    @ /glade/work/kenzhao/.julia/packages/CUDA/rXson/lib/cudadrv/execution.jl:134 [inlined]
 [15] macro expansion
    @ /glade/work/kenzhao/.julia/packages/CUDA/rXson/src/compiler/execution.jl:258 [inlined]
 [16] macro expansion
    @ ./none:0 [inlined]
 [17] call(::CUDA.HostKernel{typeof(CUDA.partial_mapreduce_grid), Tuple{typeof(identity), typeof(max), Nothing, CartesianIndices{3, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}, Base.OneTo{Int64}}}, CartesianIndices{3, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}, Base.OneTo{Int64}}}, Val{true}, CUDA.CuDeviceArray{Float64, 4, 1}, Field{Center, Center, Nothing, Nothing, Nothing, Nothing, OffsetArrays.OffsetArray{Float64, 3, CUDA.CuDeviceArray{Float64, 3, 1}}, Float64, Nothing, Nothing, Nothing}}}, ::typeof(identity), ::typeof(max), ::Nothing, ::CartesianIndices{3, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}, Base.OneTo{Int64}}}, ::CartesianIndices{3, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}, Base.OneTo{Int64}}}, ::Val{true}, ::CUDA.CuDeviceArray{Float64, 4, 1}, ::Field{Center, Center, Nothing, Nothing, Nothing, Nothing, OffsetArrays.OffsetArray{Float64, 3, CUDA.CuDeviceArray{Float64, 3, 1}}, Float64, Nothing, Nothing, Nothing}; call_kwargs::Base.Pairs{Symbol, Int64, Tuple{Symbol, Symbol, Symbol}, NamedTuple{(:threads, :blocks, :shmem), Tuple{Int64, Int64, Int64}}})
    @ CUDA ./none:0
 [18] (::CUDA.HostKernel{typeof(CUDA.partial_mapreduce_grid), Tuple{typeof(identity), typeof(max), Nothing, CartesianIndices{3, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}, Base.OneTo{Int64}}}, CartesianIndices{3, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}, Base.OneTo{Int64}}}, Val{true}, CUDA.CuDeviceArray{Float64, 4, 1}, Field{Center, Center, Nothing, Nothing, Nothing, Nothing, OffsetArrays.OffsetArray{Float64, 3, CUDA.CuDeviceArray{Float64, 3, 1}}, Float64, Nothing, Nothing, Nothing}}})(::Function, ::Vararg{Any}; threads::Int64, blocks::Int64, kwargs::Base.Pairs{Symbol, Int64, Tuple{Symbol}, NamedTuple{(:shmem,), Tuple{Int64}}})
    @ CUDA /glade/work/kenzhao/.julia/packages/CUDA/rXson/src/compiler/execution.jl:381
 [19] HostKernel
    @ /glade/work/kenzhao/.julia/packages/CUDA/rXson/src/compiler/execution.jl:380 [inlined]
 [20] macro expansion
    @ /glade/work/kenzhao/.julia/packages/CUDA/rXson/src/compiler/execution.jl:106 [inlined]


```